### PR TITLE
feat: Add top and bottom offset for content; Make horizontal scrollbar usable

### DIFF
--- a/TextControlBox-TestApp/MainWindow.xaml.cs
+++ b/TextControlBox-TestApp/MainWindow.xaml.cs
@@ -22,6 +22,8 @@ namespace TextControlBox_TestApp
             textbox.NumberOfSpacesForTab = 4;
             textbox.ShowWhitespaceCharacters = true;
 
+            textbox.ContentVerticalScrollOffset = new TextControlBoxNS.Models.Structs.VerticalScrollOffset(100, 100);
+
             SetWindowTheme(this, ElementTheme.Dark);
 
             textbox.LinkClicked += Textbox_LinkClicked;

--- a/TextControlBox/Core/CoreTextControlBox.xaml
+++ b/TextControlBox/Core/CoreTextControlBox.xaml
@@ -23,6 +23,10 @@
             <ColumnDefinition Width="auto"/>
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="auto"/>
+        </Grid.RowDefinitions>
         <xaml:CanvasControl
                     Grid.Column="0"
                     x:Name="Canvas_LineNumber"
@@ -61,8 +65,8 @@
                         VerticalAlignment="Stretch"/>
 
             <ScrollBar Grid.Column="2" PointerEntered="Scrollbar_PointerEntered" PointerExited="Scrollbar_PointerExited" SmallChange="10" Maximum="0" LargeChange="100" Minimum="0" x:Name="VerticalScrollbar" Value="0" IndicatorMode="MouseIndicator" Background="Transparent" HorizontalAlignment="Right" Orientation="Vertical" VerticalAlignment="Stretch"/>
-            <ScrollBar PointerEntered="Scrollbar_PointerEntered" PointerExited="Scrollbar_PointerExited" SmallChange="10" LargeChange="100" Minimum="0" Maximum="0" x:Name="HorizontalScrollbar" Value="0" IndicatorMode="MouseIndicator" Background="Transparent" HorizontalAlignment="Stretch" Orientation="Horizontal" VerticalAlignment="Bottom"/>
         </Grid>
+        <ScrollBar Grid.Row="2" Grid.ColumnSpan="2" PointerEntered="Scrollbar_PointerEntered" PointerExited="Scrollbar_PointerExited" SmallChange="10" LargeChange="100" Minimum="0" Maximum="0" x:Name="HorizontalScrollbar" Value="0" IndicatorMode="MouseIndicator" Background="Transparent" HorizontalAlignment="Stretch" Orientation="Horizontal" VerticalAlignment="Bottom"/>
         <controls:InputHandlerControl x:Name="inputHandler" GotFocus="InputManager_GotFocus" LostFocus="InputManager_LostFocus" PreviewKeyDown="InputHandler_KeyDown" TextEntered="InputHandler_TextEntered" Grid.Column="1" Opacity="0" Width="0" Height="0"/>
     </Grid>
 </UserControl>

--- a/TextControlBox/Core/CoreTextControlBox.xaml.cs
+++ b/TextControlBox/Core/CoreTextControlBox.xaml.cs
@@ -14,6 +14,7 @@ using TextControlBoxNS.Helper;
 using TextControlBoxNS.Languages;
 using TextControlBoxNS.Models;
 using TextControlBoxNS.Models.Enums;
+using TextControlBoxNS.Models.Structs;
 using Windows.ApplicationModel.DataTransfer;
 using Windows.Foundation;
 using Windows.System;
@@ -984,6 +985,23 @@ internal sealed partial class CoreTextControlBox : UserControl
         undoRedo.EndActionGroup();
     }
     public bool IsGroupingActions => undoRedo.IsGroupingActions;
+
+    private VerticalScrollOffset _ContentVerticalScrollOffset = new(0);
+
+    public VerticalScrollOffset ContentVerticalScrollOffset
+    {
+        get => _ContentVerticalScrollOffset;
+        set
+        {
+            _ContentVerticalScrollOffset = value;
+
+            textRenderer.UpdateScrollOffset(value);
+            Canvas_Text.UpdateLayout();
+            Canvas_Selection.UpdateLayout();
+            Canvas_Cursor.UpdateLayout();
+            Canvas_LineNumber.UpdateLayout();
+        }
+    }
 
     public bool EnableSyntaxHighlighting { get; set; } = true;
 

--- a/TextControlBox/Core/PointerActionsManager.cs
+++ b/TextControlBox/Core/PointerActionsManager.cs
@@ -393,7 +393,7 @@ internal class PointerActionsManager
         {
             scrollManager.verticalScrollBar.Value -= (delta * scrollManager._VerticalScrollSensitivity) / scrollManager.DefaultVerticalScrollSensitivity;
             //Only update when a line was scrolled
-            if ((int)(scrollManager.verticalScrollBar.Value / textRenderer.SingleLineHeight * scrollManager.DefaultVerticalScrollSensitivity) != textRenderer.NumberOfStartLine)
+            if ((int)(scrollManager.verticalScrollBar.Value / textRenderer.SingleLineHeight * scrollManager.DefaultVerticalScrollSensitivity + textRenderer.VerticalDrawOffset) != textRenderer.NumberOfStartLine)
             {
                 needsUpdate = true;
             }

--- a/TextControlBox/Core/Renderer/CursorRenderer.cs
+++ b/TextControlBox/Core/Renderer/CursorRenderer.cs
@@ -80,7 +80,7 @@ internal class CursorRenderer
         float singleLineHeight = textRenderer.SingleLineHeight;
 
         //Calculate the distance to the top for the cursorposition and render the cursor
-        float renderPosY = (float)((cursorManager.LineNumber - startLine) * singleLineHeight) + singleLineHeight / scrollManager.DefaultVerticalScrollSensitivity;
+        float renderPosY = (float)((cursorManager.LineNumber - startLine) * singleLineHeight) + singleLineHeight / scrollManager.DefaultVerticalScrollSensitivity + textRenderer.VerticalDrawOffset;
 
         //Out of display-region:
         if (renderPosY > linesToRender * singleLineHeight || renderPosY < 0)

--- a/TextControlBox/Core/Renderer/LineNumberRenderer.cs
+++ b/TextControlBox/Core/Renderer/LineNumberRenderer.cs
@@ -76,7 +76,7 @@ namespace TextControlBoxNS.Core.Renderer
 
             OldLineNumberTextToRender = LineNumberTextToRender;
             LineNumberTextLayout = textLayoutManager.CreateTextLayout(canvas, LineNumberTextFormat, LineNumberTextToRender, posX, (float)canvas.Size.Height);
-            args.DrawingSession.DrawTextLayout(LineNumberTextLayout, 10, textRenderer.SingleLineHeight, designHelper.LineNumberColorBrush);
+            args.DrawingSession.DrawTextLayout(LineNumberTextLayout, 10, textRenderer.VerticalDrawOffset + textRenderer.SingleLineHeight, designHelper.LineNumberColorBrush);
         }
 
         public void CreateLineNumberTextFormat()

--- a/TextControlBox/Core/Renderer/SelectionRenderer.cs
+++ b/TextControlBox/Core/Renderer/SelectionRenderer.cs
@@ -191,7 +191,7 @@ namespace TextControlBoxNS.Core.Renderer
                     textRenderer.DrawnTextLayout,
                     args,
                     (float)-scrollManager.HorizontalScroll,
-                    textRenderer.SingleLineHeight / scrollManager.DefaultVerticalScrollSensitivity,
+                    textRenderer.SingleLineHeight / scrollManager.DefaultVerticalScrollSensitivity + textRenderer.VerticalDrawOffset,
                     textRenderer.NumberOfStartLine,
                     textRenderer.NumberOfRenderedLines,
                     zoomManager.ZoomedFontSize,

--- a/TextControlBox/Core/ScrollManager.cs
+++ b/TextControlBox/Core/ScrollManager.cs
@@ -133,10 +133,29 @@ internal class ScrollManager
     }
     public void UpdateScrollToShowCursor(bool update = true)
     {
-        if (textRenderer.NumberOfStartLine + textRenderer.NumberOfRenderedLines <= cursorManager.LineNumber)
-            verticalScrollBar.Value = (cursorManager.LineNumber - textRenderer.NumberOfRenderedLines + 1) * textRenderer.SingleLineHeight / DefaultVerticalScrollSensitivity;
+        double globalOffset = textRenderer.VerticalDrawOffset == 0 ? textRenderer.TopScrollOffset : 0;
+
+        if (cursorManager.LineNumber == 0)
+        {
+            verticalScrollBar.Value = 0;
+        }
+        else if (textRenderer.NumberOfStartLine + textRenderer.NumberOfRenderedLines <= cursorManager.LineNumber)
+        {
+            verticalScrollBar.Value = ((cursorManager.LineNumber - textRenderer.NumberOfRenderedLines + 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity;
+        }
         else if (textRenderer.NumberOfStartLine > cursorManager.LineNumber)
-            verticalScrollBar.Value = (cursorManager.LineNumber - 1) * textRenderer.SingleLineHeight / DefaultVerticalScrollSensitivity;
+        {
+            verticalScrollBar.Value = ((cursorManager.LineNumber - 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity;
+        }
+        else if (textRenderer.VerticalDrawOffset != 0)
+        {
+            int realLineDisplayedCount = (int)((verticalScrollBar.ViewportSize - textRenderer.VerticalDrawOffset) / textRenderer.SingleLineHeight);
+            if (realLineDisplayedCount <= cursorManager.LineNumber)
+            {
+                double offsetToMove = ((cursorManager.LineNumber - realLineDisplayedCount + 1) * textRenderer.SingleLineHeight);
+                verticalScrollBar.Value = ((cursorManager.LineNumber - 1) * textRenderer.SingleLineHeight) / DefaultVerticalScrollSensitivity + offsetToMove;
+            }
+        }
 
         if (update)
             canvasHelper.UpdateAll();

--- a/TextControlBox/Core/ScrollManager.cs
+++ b/TextControlBox/Core/ScrollManager.cs
@@ -134,6 +134,7 @@ internal class ScrollManager
     public void UpdateScrollToShowCursor(bool update = true)
     {
         double globalOffset = textRenderer.VerticalDrawOffset == 0 ? textRenderer.TopScrollOffset : 0;
+        double localOffset = textRenderer.VerticalDrawOffset;
 
         if (cursorManager.LineNumber == 0)
         {
@@ -141,11 +142,11 @@ internal class ScrollManager
         }
         else if (textRenderer.NumberOfStartLine + textRenderer.NumberOfRenderedLines <= cursorManager.LineNumber)
         {
-            verticalScrollBar.Value = ((cursorManager.LineNumber - textRenderer.NumberOfRenderedLines + 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity;
+            verticalScrollBar.Value = ((cursorManager.LineNumber - textRenderer.NumberOfRenderedLines + 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity + localOffset;
         }
         else if (textRenderer.NumberOfStartLine > cursorManager.LineNumber)
         {
-            verticalScrollBar.Value = ((cursorManager.LineNumber - 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity;
+            verticalScrollBar.Value = ((cursorManager.LineNumber - 1) * textRenderer.SingleLineHeight + globalOffset) / DefaultVerticalScrollSensitivity + localOffset;
         }
         else if (textRenderer.VerticalDrawOffset != 0)
         {

--- a/TextControlBox/Core/ScrollManager.cs
+++ b/TextControlBox/Core/ScrollManager.cs
@@ -57,7 +57,7 @@ internal class ScrollManager
     internal void VerticalScrollBar_Scroll(object sender, ScrollEventArgs e)
     {
         //only update when a line was scrolled
-        if ((int)(verticalScrollBar.Value / textRenderer.SingleLineHeight * DefaultVerticalScrollSensitivity) != textRenderer.NumberOfStartLine)
+        if ((int)(verticalScrollBar.Value / textRenderer.SingleLineHeight * DefaultVerticalScrollSensitivity + textRenderer.VerticalDrawOffset ) != textRenderer.NumberOfStartLine)
         {
             canvasHelper.UpdateAll();
         }
@@ -66,7 +66,7 @@ internal class ScrollManager
     public void UpdateWhenScrolled()
     {
         //only update when a line was scrolled
-        if ((int)(verticalScrollBar.Value / textRenderer.SingleLineHeight) != textRenderer.NumberOfStartLine)
+        if ((int)(verticalScrollBar.Value / textRenderer.SingleLineHeight + textRenderer.VerticalDrawOffset) != textRenderer.NumberOfStartLine)
         {
             canvasHelper.UpdateAll();
         }

--- a/TextControlBox/Helper/CursorHelper.cs
+++ b/TextControlBox/Helper/CursorHelper.cs
@@ -14,7 +14,7 @@ internal class CursorHelper
     public static int GetCursorLineFromPoint(TextRenderer textRenderer, Point point)
     {
         //Calculate the relative linenumber, where the pointer was pressed at
-        int linenumber = (int)(point.Y / textRenderer.SingleLineHeight);
+        int linenumber = (int)((point.Y - textRenderer.VerticalDrawOffset) / textRenderer.SingleLineHeight);
         linenumber += textRenderer.NumberOfStartLine;
         return Math.Clamp(linenumber, 0, textRenderer.NumberOfStartLine + textRenderer.NumberOfRenderedLines - 1);
     }

--- a/TextControlBox/Models/Structs/VerticalScrollOffset.cs
+++ b/TextControlBox/Models/Structs/VerticalScrollOffset.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+
+namespace TextControlBoxNS.Models.Structs
+{
+    /// <summary>
+    /// Describes the offset between content and vertical scroll area borders. 
+    /// Two Double values describe the Top and Bottom offsets, respectively.
+    /// </summary>
+    public struct VerticalScrollOffset
+    {
+        private double _Top;
+
+        private double _Bottom;
+
+        /// <summary>
+        /// The top offset of content
+        /// </summary>
+        public double Top
+        {
+            get
+            {
+                return _Top;
+            }
+            set
+            {
+                _Top = value;
+            }
+        }
+
+        /// <summary>
+        /// The bottom offset of content
+        /// </summary>
+
+        public double Bottom
+        {
+            get
+            {
+                return _Bottom;
+            }
+            set
+            {
+                _Bottom = value;
+            }
+        }
+
+        /// <summary>
+        /// Creates new VerticalScrollOffset object
+        /// </summary>
+        /// <param name="uniformLength">The top and bottom content offset</param>
+        public VerticalScrollOffset(double uniformLength)
+        {
+            _Top = (_Bottom = uniformLength);
+        }
+
+        /// <summary>
+        /// Creates new VerticalScrollOffset object
+        /// </summary>
+        /// <param name="top">The top offset of content</param>
+        /// <param name="bottom">The bottom offset of content</param>
+        public VerticalScrollOffset(double top, double bottom)
+        {
+            _Top = top;
+            _Bottom = bottom;
+        }
+
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return ToString(CultureInfo.InvariantCulture);
+        }
+
+        internal string ToString(CultureInfo cultureInfo)
+        {
+            char numericListSeparator = TokenizerHelper.GetNumericListSeparator(cultureInfo);
+            StringBuilder stringBuilder = new StringBuilder(64);
+            stringBuilder.Append(InternalToString(_Top, cultureInfo));
+            stringBuilder.Append(numericListSeparator);
+            stringBuilder.Append(InternalToString(_Bottom, cultureInfo));
+            return stringBuilder.ToString();
+        }
+
+        internal string InternalToString(double l, CultureInfo cultureInfo)
+        {
+            if (double.IsNaN(l))
+            {
+                return "Unset";
+            }
+
+            return Convert.ToString(l, cultureInfo);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (obj is VerticalScrollOffset verticalScrollOffset)
+            {
+                return this == verticalScrollOffset;
+            }
+
+            return false;
+        }
+        /// <summary>
+        /// Indicates whether this instance and a specified object are equal.
+        /// </summary>
+        /// <returns>true if verticalScrollOffset and this instance are represent the same value; otherwise, false.</returns>
+        public readonly bool Equals(VerticalScrollOffset verticalScrollOffset)
+        {
+            return this == verticalScrollOffset;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return _Top.GetHashCode() ^ _Bottom.GetHashCode();
+        }
+
+        /// <summary>
+        /// Compares two VerticalScrollOffset objects
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>true if offsets are same; otherwise, false.</returns>
+        public static bool operator ==(VerticalScrollOffset t1, VerticalScrollOffset t2)
+        {
+            if (t1._Top == t2._Top)
+            {
+                return t1._Bottom == t2._Bottom;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Compares two VerticalScrollOffset objects
+        /// </summary>
+        /// <param name="t1"></param>
+        /// <param name="t2"></param>
+        /// <returns>true if offsets are different; otherwise, false.</returns>
+        public static bool operator !=(VerticalScrollOffset t1, VerticalScrollOffset t2)
+        {
+            return !(t1 == t2);
+        }
+    }
+}

--- a/TextControlBox/TextControlBox.cs
+++ b/TextControlBox/TextControlBox.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using TextControlBoxNS.Core;
 using TextControlBoxNS.Models;
+using TextControlBoxNS.Models.Structs;
 using Windows.Foundation;
 
 namespace TextControlBoxNS;
@@ -662,6 +663,15 @@ public partial class TextControlBox : UserControl
     public bool AddLines(int start, string[] text)
     {
         return coreTextBox.AddLines(start, text);
+    }
+
+    /// <summary>
+    /// Gets or sets content scroll offset
+    /// </summary>
+    public VerticalScrollOffset ContentVerticalScrollOffset
+    {
+        get => coreTextBox.ContentVerticalScrollOffset;
+        set => coreTextBox.ContentVerticalScrollOffset = value;
     }
 
     /// <summary>


### PR DESCRIPTION
## Top and bottom offset for content
If this control will be used with some flyouts (like search-replace flyout) content offset may be useful

<details><summary>For example modern notepad application</summary>

<img width="1271" height="301" alt="изображение" src="https://github.com/user-attachments/assets/e60f77ed-e588-4b66-a542-6f81e53441a0" />
<img width="1269" height="258" alt="изображение" src="https://github.com/user-attachments/assets/8c138246-5b68-40d9-aff9-9850f39a011f" />

</details>

I'm not good c# developer, but for a first look that works without any bugs. Also I worry about performance - my formulas may be not optimized

## Make horizontal scrollbar usable

9cca93704ccb91c1d6cfe80ce8e50c4c748ff7a1

Right now user can't normally edit line under scrollbar (If user enable "Always show scrollbars" in settings that line cannot be edited). If line is last editing is not possible.

<details><summary>How it look before</summary>
<img width="891" height="57" alt="изображение" src="https://github.com/user-attachments/assets/74fef4db-0281-482d-8d1f-2f8aa1c5eef9" />

User can't access line 45
</details>

<details><summary>How it look after</summary>
<img width="712" height="172" alt="изображение" src="https://github.com/user-attachments/assets/f1a16a07-91ae-4f83-9183-806de270c680" />

User can access any line without problems
</details>

