### PR TITLE
Fix: caret can fall off-screen after typing on long lines

### DIFF
--- a/TextControlBox/Core/Text/TextActionManager.cs
+++ b/TextControlBox/Core/Text/TextActionManager.cs
@@ -500,8 +500,15 @@ namespace TextControlBoxNS.Core.Text
             }
 
             eventsManager.CallTextChanged();
-            scrollManager.ScrollLineIntoViewIfOutside(cursorManager.LineNumber, false);
-            
+            // Keep the caret visible after typing using the same helper every other edit
+            // operation uses. Backspace, Delete, AddNewLine, Undo and Redo all call
+            // UpdateScrollToShowCursor; AddCharacter was the only one still using the
+            // line-granularity ScrollLineIntoViewIfOutside, which does not scroll while the
+            // caret stays on the same (long) line, so a caret typed past the right edge could
+            // fall outside the rendered area. Using the shared helper makes the caret follow
+            // consistent with the rest of the edit operations.
+            scrollManager.UpdateScrollToShowCursor(false);
+
             canvasUpdateManager.UpdateAll();
         }
 


### PR DESCRIPTION
## What

`TextActionManager.AddCharacter` was the only edit operation still using the line-granularity `ScrollManager.ScrollLineIntoViewIfOutside(...)` to keep the caret visible after an edit. Every other edit operation uses `ScrollManager.UpdateScrollToShowCursor(...)`:

| Edit op | Scroll call |
|---|---|
| Backspace / Delete / AddNewLine / Undo / Redo | `UpdateScrollToShowCursor` |
| **AddCharacter (typing)** | `ScrollLineIntoViewIfOutside` ← inconsistent |

## Why it matters

`ScrollLineIntoViewIfOutside` only scrolls when the caret's **line** is outside the viewport. While typing on a single long line, the line is always "in view", so it never scrolls to follow the caret horizontally — the caret (and the next typed character) can end up past the right edge, outside the rendered area. The other edit operations don't have this problem because they use the cursor-aware helper.

## Change

One line in `AddCharacter`: use the same `UpdateScrollToShowCursor(false)` helper the rest of the edit pipeline already uses, so caret-follow after typing is consistent with backspace/delete/newline/undo/redo.

## Testing

- Builds clean (`TextControlBox.csproj`, Release/x64).
- Behavior: typing past the right edge of a long line now keeps the caret in view, matching the other edit operations.

_This fix was developed while using TextControlBox as a vendored editor; contributing it back upstream._
