### PR TITLE
Fix: enable pinch-to-zoom on precision touchpads

### DIFF
--- a/TextControlBox/Core/PointerActionsManager.cs
+++ b/TextControlBox/Core/PointerActionsManager.cs
@@ -428,8 +428,11 @@ internal class PointerActionsManager
     {
         var delta = e.GetCurrentPoint(coreTextbox.canvasSelection).Properties.MouseWheelDelta;
         bool needsUpdate = false;
-        //Zoom using mousewheel
-        if (Utils.IsKeyPressed(VirtualKey.Control))
+        //Zoom using mousewheel or a precision-touchpad pinch. A pinch gesture is delivered by
+        //Windows as a Ctrl-modified wheel, but that Control comes from the wheel message
+        //(e.KeyModifiers), not the physical keyboard state, so Utils.IsKeyPressed alone misses it.
+        //Check both so pinch-to-zoom works on precision touchpads.
+        if (Utils.IsKeyPressed(VirtualKey.Control) || e.KeyModifiers.HasFlag(VirtualKeyModifiers.Control))
         {
             zoomManager._ZoomFactor += delta / 20;
             zoomManager.UpdateZoom();


### PR DESCRIPTION
## What

Enables **pinch-to-zoom on precision touchpads**, which currently does nothing.

## Why

`PointerActionsManager.PointerWheelAction` gates the zoom branch on `Utils.IsKeyPressed(VirtualKey.Control)`. A precision-touchpad pinch is delivered by Windows as a **Ctrl-modified mouse-wheel** message, but that `Control` flag rides on the wheel event (`PointerRoutedEventArgs.KeyModifiers`) and is **not** reflected in the physical keyboard state that `Utils.IsKeyPressed` reads. So pinching a precision touchpad falls through to the scroll branch and never zooms.

## Change

Also check `e.KeyModifiers.HasFlag(VirtualKeyModifiers.Control)` in the zoom condition. Physical Ctrl+wheel keeps working exactly as before; pinch now zooms too.

## Testing

- Builds clean (`TextControlBox.csproj`, Release/x64).
- Ctrl+mouse-wheel zoom: unchanged. Precision-touchpad pinch: now zooms.

_Contributing this back upstream after hitting it while using TextControlBox as a vendored editor._
