### PR TITLE
Add TextColor property to set base text color at runtime

### DIFF
--- a/TextControlBox/Core/CoreTextControlBox.xaml.cs
+++ b/TextControlBox/Core/CoreTextControlBox.xaml.cs
@@ -1076,6 +1076,21 @@ internal sealed partial class CoreTextControlBox : UserControl
         set => designHelper.Design = value;
     }
 
+    public Windows.UI.Color TextColor
+    {
+        get => designHelper._Design.TextColor;
+        set
+        {
+            if (designHelper._Design.TextColor.Equals(value))
+                return;
+
+            designHelper._Design.TextColor = value;
+            designHelper.ColorResourcesCreated = false;
+            textRenderer.NeedsUpdateTextLayout = true;
+            canvasUpdateManager.UpdateAll();
+        }
+    }
+
     public bool ShowLineNumbers
     {
         get => lineNumberManager._ShowLineNumbers;

--- a/TextControlBox/TextControlBox.cs
+++ b/TextControlBox/TextControlBox.cs
@@ -789,6 +789,19 @@ public partial class TextControlBox : UserControl
     }
 
     /// <summary>
+    /// Gets or sets the color of the editor body text.
+    /// </summary>
+    /// <remarks>
+    /// This is the base text color. When syntax highlighting is enabled, per-token colors from the
+    /// active <see cref="SyntaxHighlighting"/> still take precedence for highlighted tokens.
+    /// </remarks>
+    public Windows.UI.Color TextColor
+    {
+        get => coreTextBox.TextColor;
+        set => coreTextBox.TextColor = value;
+    }
+
+    /// <summary>
     /// Gets or sets a value indicating whether line numbers should be displayed in the textbox.
     /// </summary>
     public bool ShowLineNumbers


### PR DESCRIPTION
## What

Adds a public `TextColor` property to set the editor's base body-text color at runtime, without replacing the whole `Design` object.

```csharp
textBox.TextColor = Colors.Gainsboro;
```

## Why

Today the only way to change the text color is to build and assign a whole new `TextControlBoxDesign`. All the internal plumbing for a granular setter already exists:

- `TextControlBoxDesign.TextColor` (model field) ✔
- `DesignHelper.TextColorBrush` + `CreateColorResources()` (already builds the brush from `_Design.TextColor`) ✔
- `TextRenderer` already draws body text with `designHelper.TextColorBrush` ✔

The only thing missing was a public property to change it and invalidate. This mirrors the existing granular properties (`ShowLineNumbers`, `ShowLineHighlighter`, etc.).

## Change

- `CoreTextControlBox`: new `TextColor` property — updates `_Design.TextColor`, forces `ColorResourcesCreated = false` (so the brush is rebuilt), flags `NeedsUpdateTextLayout`, and redraws. No-ops when the value is unchanged.
- `TextControlBox` (public wrapper): forwards `TextColor` to the core control, with an XML doc note that syntax-highlighting token colors still take precedence when enabled.

## Testing

- Builds clean (`TextControlBox.csproj`, Release/x64).
- Setting `TextColor` recolors the body text immediately; with syntax highlighting on, non-token text uses the new color while token colors are unaffected.

_Extracted from downstream use of TextControlBox as a vendored editor and contributed back._
