### PR TITLE
Add a blinking text caret

### DIFF
--- a/TextControlBox/Core/CanvasUpdateManager.cs
+++ b/TextControlBox/Core/CanvasUpdateManager.cs
@@ -23,7 +23,20 @@ internal class CanvasUpdateManager
         if (!coreTextbox.canvasCursor.ReadyToDraw)
             return;
 
+        coreTextbox.caretBlinkManager?.NotifyCaretActivity();
+
         //coreTextbox.canvasCursor.Invalidate();
+        _batchRedrawer.RequestRedraw(coreTextbox.canvasCursor);
+    }
+
+    // Redraw the caret canvas for a blink-phase toggle WITHOUT resetting the blink
+    // phase. UpdateCursor resets the phase via NotifyCaretActivity, so the blink
+    // timer must use this path or the caret would never blink.
+    public void RedrawCursorForBlink()
+    {
+        if (!coreTextbox.canvasCursor.ReadyToDraw)
+            return;
+
         _batchRedrawer.RequestRedraw(coreTextbox.canvasCursor);
     }
     public void UpdateText()

--- a/TextControlBox/Core/CaretBlinkManager.cs
+++ b/TextControlBox/Core/CaretBlinkManager.cs
@@ -1,0 +1,64 @@
+using Microsoft.UI.Dispatching;
+using System;
+
+namespace TextControlBoxNS.Core;
+
+/// <summary>
+/// Drives the always-on blinking of the text caret. While the editor is focused the
+/// caret toggles between visible and hidden on a fixed interval; cursor activity
+/// (typing, moving the caret) resets the phase so the caret stays solid for a full
+/// interval, matching standard text-editor behavior.
+/// </summary>
+internal class CaretBlinkManager
+{
+    // Windows default caret blink interval (the GetCaretBlinkTime default is 530ms).
+    private const int BlinkIntervalMs = 530;
+
+    private CanvasUpdateManager canvasUpdateManager;
+    private DispatcherQueueTimer timer;
+
+    /// <summary>True while the caret should be painted for the current blink phase.</summary>
+    public bool IsCaretVisible { get; private set; } = true;
+
+    public void Init(CanvasUpdateManager canvasUpdateManager)
+    {
+        this.canvasUpdateManager = canvasUpdateManager;
+
+        timer = DispatcherQueue.GetForCurrentThread().CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(BlinkIntervalMs);
+        timer.Tick += (s, e) =>
+        {
+            IsCaretVisible = !IsCaretVisible;
+            canvasUpdateManager.RedrawCursorForBlink();
+        };
+    }
+
+    /// <summary>Begin (or restart) blinking with the caret shown for a full interval.</summary>
+    public void Start()
+    {
+        IsCaretVisible = true;
+        if (timer != null && !timer.IsRunning)
+            timer.Start();
+    }
+
+    /// <summary>Stop blinking and leave the caret hidden (it only paints while focused).</summary>
+    public void Stop()
+    {
+        IsCaretVisible = false;
+        timer?.Stop();
+    }
+
+    /// <summary>
+    /// Keep the caret solid for a full interval after cursor activity (typing, moving),
+    /// so it doesn't blink mid-keystroke. No-op until the blink timer is running.
+    /// </summary>
+    public void NotifyCaretActivity()
+    {
+        IsCaretVisible = true;
+        if (timer != null && timer.IsRunning)
+        {
+            timer.Stop();
+            timer.Start();
+        }
+    }
+}

--- a/TextControlBox/Core/CoreTextControlBox.xaml.cs
+++ b/TextControlBox/Core/CoreTextControlBox.xaml.cs
@@ -36,6 +36,7 @@ internal sealed partial class CoreTextControlBox : UserControl
     public readonly TextActionManager textActionManager;
     public readonly TextRenderer textRenderer;
     public readonly CursorRenderer cursorRenderer;
+    public readonly CaretBlinkManager caretBlinkManager;
     public readonly ScrollManager scrollManager;
     public readonly CurrentLineManager currentLineManager;
     public readonly LongestLineManager longestLineManager;
@@ -91,6 +92,7 @@ internal sealed partial class CoreTextControlBox : UserControl
         textActionManager = new TextActionManager();
         textRenderer = new TextRenderer();
         cursorRenderer = new CursorRenderer();
+        caretBlinkManager = new CaretBlinkManager();
         scrollManager = new ScrollManager();
         currentLineManager = new CurrentLineManager();
         longestLineManager = new LongestLineManager();
@@ -124,9 +126,10 @@ internal sealed partial class CoreTextControlBox : UserControl
         selectionRenderer.Init(selectionManager, textRenderer, eventsManager, scrollManager, zoomManager, designHelper, textManager);
         flyoutHelper.Init(this);
         canvasUpdateManager.Init(this);
+        caretBlinkManager.Init(canvasUpdateManager);
         textActionManager.Init(this, textRenderer, undoRedo, currentLineManager, longestLineManager, canvasUpdateManager, textManager, selectionRenderer, cursorManager, scrollManager, eventsManager, stringManager, selectionManager, autoIndentionManager);
         textRenderer.Init(cursorManager, designHelper, textLayoutManager, textManager, scrollManager, lineNumberRenderer, longestLineManager, this, searchManager, canvasUpdateManager, zoomManager, invisibleCharactersRenderer, linkRenderer, linkHighlightManager);
-        cursorRenderer.Init(cursorManager, currentLineManager, textRenderer, focusManager, textManager, scrollManager, zoomManager, designHelper, lineHighlighterRenderer, eventsManager, longestLineManager);
+        cursorRenderer.Init(cursorManager, currentLineManager, textRenderer, focusManager, textManager, scrollManager, zoomManager, designHelper, lineHighlighterRenderer, eventsManager, longestLineManager, caretBlinkManager);
         scrollManager.Init(this, canvasUpdateManager, textManager, textRenderer, cursorManager, zoomManager, VerticalScrollbar, HorizontalScrollbar);
         currentLineManager.Init(cursorManager, textManager);
         longestLineManager.Init(selectionManager, textManager, textRenderer);
@@ -932,6 +935,8 @@ internal sealed partial class CoreTextControlBox : UserControl
         {
             horizontalScrollBar.Scroll -= scrollManager.HorizontalScrollBar_Scroll;
         }
+
+        caretBlinkManager.Stop();
 
         textRenderer.CheckDispose();
         lineNumberRenderer.CheckDispose();

--- a/TextControlBox/Core/FocusManager.cs
+++ b/TextControlBox/Core/FocusManager.cs
@@ -27,6 +27,7 @@ internal class FocusManager
 
         HasFocus = true;
         eventsManager.CallGotFocus();
+        coreTextbox.caretBlinkManager.Start();
         canvasUpdateManager.UpdateCursor();
 
         coreTextbox.ChangeCursor(InputSystemCursorShape.IBeam);
@@ -38,6 +39,7 @@ internal class FocusManager
         canvasUpdateManager.UpdateCursor();
 
         HasFocus = false;
+        coreTextbox.caretBlinkManager.Stop();
         coreTextbox.ChangeCursor(InputSystemCursorShape.Arrow);
     }
 }

--- a/TextControlBox/Core/Renderer/CursorRenderer.cs
+++ b/TextControlBox/Core/Renderer/CursorRenderer.cs
@@ -23,6 +23,7 @@ internal class CursorRenderer
     private LineHighlighterRenderer lineHighlighterRenderer;
     private EventsManager eventsManager;
     private LongestLineManager longestLineManager;
+    private CaretBlinkManager caretBlinkManager;
 
     public void Init(
         CursorManager cursorManager,
@@ -35,7 +36,8 @@ internal class CursorRenderer
         DesignHelper designHelper,
         LineHighlighterRenderer lineHighlighterRenderer,
         EventsManager eventsManager,
-        LongestLineManager longestLineManager)
+        LongestLineManager longestLineManager,
+        CaretBlinkManager caretBlinkManager)
     {
         this.cursorManager = cursorManager;
         this.currentLineManager = currentLineManager;
@@ -48,6 +50,7 @@ internal class CursorRenderer
         this.lineHighlighterRenderer = lineHighlighterRenderer;
         this.eventsManager = eventsManager;
         this.longestLineManager = longestLineManager;
+        this.caretBlinkManager = caretBlinkManager;
     }
 
     public void RenderCursor(CanvasTextLayout textLayout, int characterPosition, float xOffset, float y, float fontSize, CursorSize customSize, CanvasDrawEventArgs args, CanvasSolidColorBrush cursorColorBrush)
@@ -91,15 +94,20 @@ internal class CursorRenderer
             if (characterPos > currentLineLength)
                 characterPos = currentLineLength;
 
-            RenderCursor(
-                textRenderer.CurrentLineTextLayout,
-                characterPos,
-                (float)-scrollManager.HorizontalScroll,
-                renderPosY,
-                zoomManager.ZoomedFontSize,
-                _CursorSize,
-                args,
-                designHelper.CursorColorBrush);
+            // Only paint the caret during the "on" phase of the blink. The current-line highlighter
+            // below stays unconditional so the highlighted line does not flicker while the caret blinks.
+            if (caretBlinkManager.IsCaretVisible)
+            {
+                RenderCursor(
+                    textRenderer.CurrentLineTextLayout,
+                    characterPos,
+                    (float)-scrollManager.HorizontalScroll,
+                    renderPosY,
+                    zoomManager.ZoomedFontSize,
+                    _CursorSize,
+                    args,
+                    designHelper.CursorColorBrush);
+            }
 
             if (!cursorManager.Equals(cursorManager.currentCursorPosition, cursorManager.oldCursorPosition))
             {


### PR DESCRIPTION
## What

Adds a **blinking text caret**. Currently the caret is drawn solid on every cursor-canvas redraw and never blinks.

## How

A small `CaretBlinkManager` drives the blink while the control is focused:

- Toggles an `IsCaretVisible` flag on a `DispatcherQueueTimer` at **530 ms** (the Windows default caret interval).
- `CursorRenderer.Draw` gates **only** the `RenderCursor(...)` call on `IsCaretVisible`. The current-line highlighter stays unconditional, so the highlighted line doesn't flicker while the caret blinks. Because Win2D clears the caret canvas each draw, skipping the paint yields a real blink.
- Cursor activity keeps the caret solid so it never blinks mid-keystroke: `CanvasUpdateManager.UpdateCursor()` calls `NotifyCaretActivity()` (resets the phase). The blink timer redraws via a separate `RedrawCursorForBlink()` that does **not** reset the phase (otherwise the caret would never toggle).
- The timer runs only while focused: `FocusManager.SetFocus()` → `Start()`, `RemoveFocus()` → `Stop()`, and `Unload()` stops it too.

## Files

- **New** `Core/CaretBlinkManager.cs`.
- `Core/CoreTextControlBox.xaml.cs` — construct/init the manager, pass it to `CursorRenderer.Init`, stop it in `Unload`.
- `Core/Renderer/CursorRenderer.cs` — gate the caret paint on `IsCaretVisible`.
- `Core/FocusManager.cs` — start/stop on focus change.
- `Core/CanvasUpdateManager.cs` — `NotifyCaretActivity()` + `RedrawCursorForBlink()`.

## Testing

- Builds clean (`TextControlBox.csproj`, Release/x64).
- Focused: caret blinks at ~530 ms; typing/moving keeps it solid for a full interval then resumes. Unfocused: caret is not painted (unchanged). No blink timer runs while unfocused.

_Contributing this back upstream after adding it for a downstream editor built on TextControlBox._
